### PR TITLE
56 filters must indicate all when nothing is selected

### DIFF
--- a/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
+++ b/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
@@ -41,7 +41,14 @@ import {
   updateFilterSelection as updateFilterAction,
 } from "data/store/features/emissions/ranges/EmissionRangesSlice"
 import _ from "lodash"
-import { ChangeEvent, memo, useCallback, useMemo, useState } from "react"
+import {
+  ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { useSelector } from "react-redux"
 
 // import { DateRangePicker, SingleInputDateRangeField } from '@mui/x-date-pickers-pro';
@@ -156,6 +163,25 @@ const EntityControlForm = memo(
       checkCallback,
     )
     const theme = useTheme()
+    const [conditionnalStyleToSelectValue, setConditionnalStyleToSelectValue] =
+      useState({})
+
+    const updateSelectStyleToItalicWhenHisValueIsACustomValue = () => {
+      if (
+        selectedLabels.includes("All") ||
+        selectedLabels.filter((label) => label.endsWith("elements selected"))
+          .length > 0
+      ) {
+        setConditionnalStyleToSelectValue({ "font-style": "italic" })
+      } else {
+        setConditionnalStyleToSelectValue({})
+      }
+    }
+
+    useEffect(() => {
+      updateSelectStyleToItalicWhenHisValueIsACustomValue()
+    }, [conditionnalStyleToSelectValue])
+
     return (
       <FormControl sx={{ mt: -3, width: 220 }}>
         <Typography sx={StyleLabel}>
@@ -166,7 +192,12 @@ const EntityControlForm = memo(
           Business Entity / Facility
         </Typography>
         {/* <InputLabel>Business Entity / Facility</InputLabel> */}
-        <Select value={selectedLabels} renderValue={multiSelectJoiner} multiple>
+        <Select
+          value={selectedLabels}
+          renderValue={multiSelectJoiner}
+          sx={conditionnalStyleToSelectValue}
+          multiple
+        >
           {entityCheckboxes}
         </Select>
       </FormControl>
@@ -292,9 +323,19 @@ const GlobalFilterMenu = ({ closeDialog, ...sxProps }: Props) => {
   )
 
   const entityLabel = useMemo(() => {
-    const entityNames = selectedBusinessEntities.map(
-      (id) => alignedIndexes.entities[id].name,
-    )
+    const entityNames: string[] = []
+    if (selectedBusinessEntities.length > 2) {
+      entityNames.push(`${selectedBusinessEntities.length} elements selected`)
+    } else if (!selectedBusinessEntities.length) {
+      // TODO Add All if all element are checked
+      entityNames.push("All")
+    } else {
+      entityNames.push(
+        ...(selectedBusinessEntities?.map(
+          (id) => alignedIndexes.entities[id].name,
+        ) ?? []),
+      )
+    }
     entityNames.sort()
     return entityNames
   }, [selectedBusinessEntities])

--- a/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
+++ b/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
@@ -143,6 +143,11 @@ const StyleLabel = () => ({
   marginBottom: 0.3,
 })
 
+/**
+ * hook to change style for selector value when needed
+ * @param labels string[]
+ * @returns
+ */
 const useConditionnalStyleToSelectorValue = (labels: string[]) => {
   const [conditionnalStyleToSelectValue, setConditionnalStyleToSelectValue] =
     useState({})

--- a/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
+++ b/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
@@ -142,6 +142,24 @@ const StyleLabel = () => ({
   lineHeight: "24px",
   marginBottom: 0.3,
 })
+
+const useConditionnalStyleToSelectorValue = (labels: string[]) => {
+  const [conditionnalStyleToSelectValue, setConditionnalStyleToSelectValue] =
+    useState({})
+
+  useEffect(() => {
+    if (
+      labels.includes("All") ||
+      labels.filter((label) => label.endsWith("elements selected")).length > 0
+    ) {
+      setConditionnalStyleToSelectValue({ "font-style": "italic" })
+    } else {
+      setConditionnalStyleToSelectValue({})
+    }
+  }, [labels])
+  return conditionnalStyleToSelectValue
+}
+
 const EntityControlForm = memo(
   ({
     allEntities,
@@ -163,24 +181,8 @@ const EntityControlForm = memo(
       checkCallback,
     )
     const theme = useTheme()
-    const [conditionnalStyleToSelectValue, setConditionnalStyleToSelectValue] =
-      useState({})
-
-    const updateSelectStyleToItalicWhenHisValueIsACustomValue = () => {
-      if (
-        selectedLabels.includes("All") ||
-        selectedLabels.filter((label) => label.endsWith("elements selected"))
-          .length > 0
-      ) {
-        setConditionnalStyleToSelectValue({ "font-style": "italic" })
-      } else {
-        setConditionnalStyleToSelectValue({})
-      }
-    }
-
-    useEffect(() => {
-      updateSelectStyleToItalicWhenHisValueIsACustomValue()
-    }, [conditionnalStyleToSelectValue])
+    const conditionnalStyleToSelectValue =
+      useConditionnalStyleToSelectorValue(selectedLabels)
 
     return (
       <FormControl sx={{ mt: -3, width: 220 }}>
@@ -221,6 +223,7 @@ const AreaControlForm = memo(
   }) => {
     const downSM = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"))
     const theme = useTheme()
+    const conditionnalStyleToSelectValue = useConditionnalStyleToSelectorValue(selectedAreaLabels)
     const areaCheckboxes = areasToCheckboxes(
       allAreas,
       selectedAreas,
@@ -241,6 +244,7 @@ const AreaControlForm = memo(
         <Select
           value={selectedAreaLabels}
           renderValue={multiSelectJoiner}
+          sx={conditionnalStyleToSelectValue}
           multiple
         >
           {areaCheckboxes}
@@ -341,7 +345,17 @@ const GlobalFilterMenu = ({ closeDialog, ...sxProps }: Props) => {
   }, [selectedBusinessEntities])
 
   const areaLabel = useMemo(() => {
-    const areasNames = selectedAreas.map((id) => alignedIndexes.areas[id].name)
+    const areasNames: string[] = []
+    if (selectedAreas.length > 2) {
+      areasNames.push(`${selectedAreas.length} elements selected`)
+    } else if (!selectedAreas.length) {
+      // TODO Add All if all element are checked
+      areasNames.push("All")
+    } else {
+      areasNames.push(
+        ...(selectedAreas?.map((id) => alignedIndexes.areas[id].name) ?? []),
+      )
+    }
     areasNames.sort()
     return areasNames
   }, [selectedAreas])

--- a/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
+++ b/src/app-layout/Header/SubHeaderContent/EmissionFilterMenu.tsx
@@ -223,7 +223,8 @@ const AreaControlForm = memo(
   }) => {
     const downSM = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"))
     const theme = useTheme()
-    const conditionnalStyleToSelectValue = useConditionnalStyleToSelectorValue(selectedAreaLabels)
+    const conditionnalStyleToSelectValue =
+      useConditionnalStyleToSelectorValue(selectedAreaLabels)
     const areaCheckboxes = areasToCheckboxes(
       allAreas,
       selectedAreas,

--- a/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
+++ b/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
@@ -1,14 +1,13 @@
 import { Box, Checkbox, FormControlLabel } from "@mui/material"
 import { MinusOutlined, PlusOutlined } from "@ant-design/icons"
-import { ChangeEvent, ReactElement, useState } from "react"
+import { ChangeEvent, ReactNode, useState } from "react"
 import IconButton from "../../../@extended/IconButton"
 
 type CheckboxItemProps = {
   label: string
-  indeterminate?: boolean
   onCheckedListener?: (event: ChangeEvent<HTMLInputElement>) => void
   isSelected?: boolean
-  children?: ReactElement
+  children?: ReactNode
 }
 
 export const CheckboxItem = ({
@@ -16,7 +15,6 @@ export const CheckboxItem = ({
   onCheckedListener,
   isSelected,
   children,
-  indeterminate = false,
 }: CheckboxItemProps) => {
   const [expanded, setExpanded] = useState(isSelected)
 
@@ -41,8 +39,6 @@ export const CheckboxItem = ({
             color: "#000",
             borderRadius: "2px",
             borderColor: "#D9D9D9",
-            visibility: () =>
-              children?.props.children.length ? "visible" : "hidden",
           }}
         >
           {expanded ? <MinusOutlined /> : <PlusOutlined />}
@@ -50,11 +46,7 @@ export const CheckboxItem = ({
         <FormControlLabel
           label={label}
           control={
-            <Checkbox
-              checked={isSelected}
-              onChange={onCheckedListener}
-              indeterminate={indeterminate}
-            />
+            <Checkbox checked={isSelected} onChange={onCheckedListener} />
           }
         />
       </Box>

--- a/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
+++ b/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
@@ -5,6 +5,7 @@ import IconButton from "../../../@extended/IconButton"
 
 type CheckboxItemProps = {
   label: string
+  indeterminate: boolean
   onCheckedListener?: (event: ChangeEvent<HTMLInputElement>) => void
   isSelected?: boolean
   children?: ReactNode
@@ -15,6 +16,7 @@ export const CheckboxItem = ({
   onCheckedListener,
   isSelected,
   children,
+  indeterminate = true,
 }: CheckboxItemProps) => {
   const [expanded, setExpanded] = useState(isSelected)
 
@@ -46,7 +48,11 @@ export const CheckboxItem = ({
         <FormControlLabel
           label={label}
           control={
-            <Checkbox checked={isSelected} onChange={onCheckedListener} />
+            <Checkbox
+              checked={isSelected}
+              onChange={onCheckedListener}
+              indeterminate={indeterminate}
+            />
           }
         />
       </Box>

--- a/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
+++ b/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
@@ -1,14 +1,14 @@
 import { Box, Checkbox, FormControlLabel } from "@mui/material"
 import { MinusOutlined, PlusOutlined } from "@ant-design/icons"
-import { ChangeEvent, ReactNode, useState } from "react"
+import { ChangeEvent, ReactElement, useState } from "react"
 import IconButton from "../../../@extended/IconButton"
 
 type CheckboxItemProps = {
   label: string
-  indeterminate: boolean
+  indeterminate?: boolean
   onCheckedListener?: (event: ChangeEvent<HTMLInputElement>) => void
   isSelected?: boolean
-  children?: ReactNode
+  children?: ReactElement
 }
 
 export const CheckboxItem = ({
@@ -41,6 +41,8 @@ export const CheckboxItem = ({
             color: "#000",
             borderRadius: "2px",
             borderColor: "#D9D9D9",
+            visibility: () =>
+              children?.props.children.length ? "visible" : "hidden",
           }}
         >
           {expanded ? <MinusOutlined /> : <PlusOutlined />}

--- a/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
+++ b/src/components/natixarComponents/AreaCheckbox/CheckboxItem/index.tsx
@@ -16,7 +16,7 @@ export const CheckboxItem = ({
   onCheckedListener,
   isSelected,
   children,
-  indeterminate = true,
+  indeterminate = false,
 }: CheckboxItemProps) => {
   const [expanded, setExpanded] = useState(isSelected)
 


### PR DESCRIPTION
# Entity Selector
- [x] Add term All on no filter
- [ ] Add term All on full check
- [x] Add term several on partial filter more than 2 selected
- [ ] Put checkbox in indeterminate when their child was partially checked
# Area Selector
- [x] Add term All on no filter
- [ ] Add term All on full check
- [x] Add term several on partial filter more than 2 selected
- [ ] Put checkbox in indeterminate when their child was partially checked
