### PR TITLE
87 wrong result in bar chart and stacked areas chart

### DIFF
--- a/src/components/charts/emissions/EmissionByKeyStacked.tsx
+++ b/src/components/charts/emissions/EmissionByKeyStacked.tsx
@@ -1,6 +1,6 @@
 import { SxProps } from "@mui/system"
 import { ApexOptions } from "apexcharts"
-import { formatEmissionAmount } from "data/domain/transformers/EmissionTransformers"
+import { formatEmissionAmount, formatEmissionIntensityUnit } from "data/domain/transformers/EmissionTransformers"
 import { memo, useMemo } from "react"
 import ReactApexChart from "react-apexcharts"
 import { getOpaqueColorByCategory } from "utils/CategoryColors"
@@ -12,7 +12,7 @@ const defaultOptions: ApexOptions = {
   },
   yaxis: {
     title: {
-      text: "Emissions",
+      text: "Emission Intensity",
     },
     labels: {
       formatter(val) {
@@ -52,17 +52,19 @@ const optionOverrides = (keys: string[]): ApexOptions => ({
     labels: {
       rotate: -30,
       rotateAlways: true,
-    },
+      },
   },
 })
 
 const EmissionByKeyStacked = ({
   groupedData,
   keys,
+  timeUnit,
   ...sxProps
 }: {
   groupedData: Record<string, Record<string, number>>
   keys: string[]
+  timeUnit: string
 } & SxProps) => {
   const series = useMemo(() => {
     const categories = Object.keys(groupedData)
@@ -94,7 +96,21 @@ const EmissionByKeyStacked = ({
     return chartData
   }, [groupedData, keys])
 
-  const options = { ...defaultOptions, ...optionOverrides(keys) }
+  const options = useMemo(() => {
+    return {
+      ...defaultOptions,
+      ...optionOverrides(keys),
+      yaxis: {
+        ...defaultOptions.yaxis,
+        labels: {
+          formatter(val: number) {
+            return `${formatEmissionAmount(val)}/${formatEmissionIntensityUnit(timeUnit)}`
+          },
+        },
+      },
+    }
+  }, [keys, timeUnit])
+  
   return (
     <ReactApexChart
       sx={{ sxProps }}

--- a/src/data/domain/transformers/EmissionTransformers.ts
+++ b/src/data/domain/transformers/EmissionTransformers.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from "uuid"
-import { TimeWindow } from "data/domain/types/time/TimeRelatedTypes"
+import { TimeRange, TimeWindow } from "data/domain/types/time/TimeRelatedTypes"
 import { CountryLocation } from "data/domain/types/participants/ContributorsTypes"
 import { IndexesContainer } from "data/store/features/emissions/ranges/EndpointTypes"
 import {
@@ -18,6 +18,7 @@ import {
   slotsAreInSameYear,
 } from "./TimeTransformers"
 import { IndexOf } from "../types/structures/StructuralTypes"
+
 
 const emptyDecimal = ".0"
 
@@ -61,9 +62,28 @@ export const formatEmissionAmount = (kgCO2eqAmount: number): string => {
   return `${formattedAmount} ${measureUnits[measureUnitIndex]}`
 }
 
+export const formatEmissionIntensityUnit = (scale: string): string => {
+  switch (scale.toLowerCase()) {
+    case "year":
+      return "yr"
+    case "quarter":
+      return "qtr"
+    case "month":
+      return "mth"
+    case "day":
+      return "dy"
+    case "hour":
+      return "hr"
+    default:
+      return ""
+  }
+}
 export const extractNameOfEra = (era: string | undefined) => {
   if (typeof era === "undefined") {
     return ""
+  }
+  if (era === "") {
+      return "Upstream"
   }
   switch (era.toLowerCase()) {
     case "d":
@@ -84,11 +104,27 @@ const calculateTotalAmount = (
   timeWindow: TimeWindow,
 ): number => {
   const startTimeSlot = dataPoint[CdpLayoutItem.CDP_LAYOUT_START]
-  const endTimeSlot = dataPoint[CdpLayoutItem.CDP_LAYOUT_END]
+  let endTimeSlot = dataPoint[CdpLayoutItem.CDP_LAYOUT_END]
+  const maxSlot = timeWindow.timeOffsets.length - 2; // to be able to getTimeDeltaforSlot need slot plus slot+1
 
-  const duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_START_PERCENTAGE] * getTimeDeltaForSlot(startTimeSlot, timeWindow) +
+  let duration = 0;
+  // handle cases where a datapoint timeslot is out of bounds
+  if (startTimeSlot > maxSlot) {
+    // completely outside bounds, cannot do calculation
+    duration = 0;
+  } else if (startTimeSlot == maxSlot) {
+    // only count start slot
+    duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_START_PERCENTAGE] * getTimeDeltaForSlot(startTimeSlot, timeWindow)
+  } else if (endTimeSlot > maxSlot) {
+    // count from start until max slot
+    duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_START_PERCENTAGE] * getTimeDeltaForSlot(startTimeSlot, timeWindow) +
+    (getTimeOffsetForSlot(maxSlot, timeWindow) - getTimeOffsetForSlot(startTimeSlot + 1, timeWindow))
+  } else {
+    // standard calculation
+    duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_START_PERCENTAGE] * getTimeDeltaForSlot(startTimeSlot, timeWindow) +
     dataPoint[CdpLayoutItem.CDP_LAYOUT_END_PERCENTAGE] * getTimeDeltaForSlot(endTimeSlot - 1, timeWindow) +
     (getTimeOffsetForSlot(endTimeSlot - 1, timeWindow) - getTimeOffsetForSlot(startTimeSlot + 1, timeWindow))
+  }
 
   // The data point is in kgCO2eq/s so duration in ms must be divided by 1000
   return dataPoint[CdpLayoutItem.CDP_LAYOUT_INTENSITY] * duration / 1000
@@ -155,7 +191,6 @@ export const dataPointsGroupBySomeIdAndCategory = (
     if (typeof result[categoryEra] === "undefined") {
       result[categoryEra] = {}
     }
-    // Make byCategory point to one branch of "result".
     const byCategory = result[categoryEra]
 
     const groupKey = groupKeyFunc(emissionPoint)
@@ -176,7 +211,7 @@ export const dataPointsGroupByCountryAndCategory = (
   points: EmissionDataPoint[],
 ) => dataPointsGroupBySomeIdAndCategory(points, (point) => point.countryId)
 
-export const emissionsGroupByTime = (
+export const emissionsIntensityGroupByTime = (
   points: EmissionDataPoint[],
   timeWindow: TimeWindow,
   timeMeasureKeyFn: (timestamp: number, showYear: boolean) => string,
@@ -188,74 +223,174 @@ export const emissionsGroupByTime = (
 
   // Loop over all emission points defined in data/domain/types/emissions/EmissionTypes.ts#L9
   points.forEach((emissionPoint) => {
-    // TODO: We don't need era here; swap for category group
     const categoryEra = emissionPoint.categoryEraName
-    // Initialize result for era if needed 
+    // Initialize result for era if needed TODO: swap for category code
     if (!result[categoryEra]) {
       result[categoryEra] = {}
     }
 
-    // Make byCategory an alias of result[categoryEra]
-    const byCategory = result[categoryEra]
-    // Emission Point "Slot" information is in fact a slot boundary.
-    // For 12 months, valid values are 0 to 12. For 12 "slots", 13 boundaries.
-    let currentTimeSlot = emissionPoint.startTimeSlot
+    if (emissionPoint.startTimeSlot < timeWindow.timeOffsets.length - 1) // test data contains values out of bounds
+    {
 
-    let totalTimeOffset = getTimeOffsetForSlot(
-      currentTimeSlot,
-      timeWindow,
-    )
-    // A 1-month aligned emissions is:  [X, 100%, intens, X+1, 100%, coordinates]
-    const singleSlot = (emissionPoint.startTimeSlot == emissionPoint.endTimeSlot - 1)
-    
-    if (singleSlot) {
-	    const timeKey = timeMeasureKeyFn(
-	      timeWindow.startTimestamp + totalTimeOffset,
-	      showYear,
-	    )
-	    const currentSlotDelta = getTimeDeltaForSlot(currentTimeSlot, timeWindow)
+      // Make byCategory an alias of result[categoryEra]
+      const byCategory = result[categoryEra]
+      // Emission Point "Slot" information is in fact a slot boundary.
+      // For 12 months, valid values are 0 to 12. For 12 "slots", 13 boundaries.
+      let currentTimeSlot = emissionPoint.startTimeSlot
+	
+      let totalTimeOffset = getTimeOffsetForSlot(
+        emissionPoint.startTimeSlot,
+        timeWindow,
+      )
+      // A 1-month aligned emissions is:  [X, 100%, intens, X+1, 100%, coordinates]
+      const singleSlot = (emissionPoint.startTimeSlot == emissionPoint.endTimeSlot - 1)
 
-	    if (!byCategory[timeKey]) {
-	      byCategory[timeKey] = 0
-	    }
-	    // Scale emissions
-	    const percent = emissionPoint.endEmissionPercentage - (1.0 - emissionPoint.startEmissionPercentage)
-	    const amount = emissionPoint.emissionIntensity * currentSlotDelta / 1000  // intensity in kg/s, slot delta in ms
-	    byCategory[timeKey] += percent * amount
-    } else {
-		  do {
-		    const timeKey = timeMeasureKeyFn(
-		      timeWindow.startTimestamp + totalTimeOffset,
-		      showYear,
-		    )
-		    const currentSlotDelta = getTimeDeltaForSlot(currentTimeSlot, timeWindow)
+      if (singleSlot) {
+        const timeKey = timeMeasureKeyFn(
+          timeWindow.startTimestamp + totalTimeOffset,
+          showYear,
+        )
+        const currentSlotDelta = getTimeDeltaForSlot(currentTimeSlot, timeWindow)
 
-		    if (!byCategory[timeKey]) {
-		      byCategory[timeKey] = 0
-		    }
+        if (!byCategory[timeKey]) {
+          byCategory[timeKey] = 0
+        }
+        // Scale emissions
+        const percent = emissionPoint.endEmissionPercentage - (1.0 - emissionPoint.startEmissionPercentage)
+        const amount = emissionPoint.emissionIntensity * currentSlotDelta / 1000  // intensity in kg/s, slot delta in ms
+        byCategory[timeKey] += percent * amount
+      } else {
+        do {
+          const timeKey = timeMeasureKeyFn(
+            timeWindow.startTimestamp + totalTimeOffset,
+            showYear,
+          )
+          const currentSlotDelta = getTimeDeltaForSlot(currentTimeSlot, timeWindow)
 
-		    let amount = emissionPoint.emissionIntensity * currentSlotDelta / 1000  // intensity in kg/s, slot delta in ms
-		    // BUG: This code is not correct in the very common case when startTimeSlot == endTimeSlot !	
-		    switch (currentTimeSlot) {
-		      case emissionPoint.startTimeSlot:
-		        amount *= emissionPoint.startEmissionPercentage
-		        break
-		      case emissionPoint.endTimeSlot - 1:
-		        amount *= emissionPoint.endEmissionPercentage
-		        break
-		      default:
-		        break
-		    }
-		    // Accumulate emissions into "result" via alias
-		    byCategory[timeKey] += amount
+          if (!byCategory[timeKey]) {
+            byCategory[timeKey] = 0
+          }
 
-		    totalTimeOffset += currentSlotDelta
-		    currentTimeSlot += 1
-		  } while (currentTimeSlot < emissionPoint.endTimeSlot)
-		}
+          let amount = emissionPoint.emissionIntensity * currentSlotDelta / 1000  // intensity in kg/s, slot delta in ms
+          // BUG: This code is not correct in the very common case when startTimeSlot == endTimeSlot !	
+          switch (currentTimeSlot) {
+            case emissionPoint.startTimeSlot:
+              amount *= emissionPoint.startEmissionPercentage
+              break
+            case emissionPoint.endTimeSlot - 1:
+              amount *= emissionPoint.endEmissionPercentage
+              break
+            default:
+              break
+          }
+          // Accumulate emissions into "result" via alias
+          byCategory[timeKey] += amount
+
+          totalTimeOffset += currentSlotDelta
+          currentTimeSlot += 1
+        } while (currentTimeSlot < emissionPoint.endTimeSlot)
+      }
+    }
   })
   return result
 }
+
+export const emissionsGroupByTime = (
+  points: EmissionDataPoint[],
+  timeWindow: TimeWindow,
+  timeMeasureKeyFn: (timestamp: number, showYear: boolean) => string,
+): Record<string, Record<string, number>> => {
+  const result: Record<string, Record<string, number>> = {}
+  const minTime = Math.min(...points.map((point) => point.startTimeSlot))
+  const maxTime = Math.max(...points.map((point) => point.endTimeSlot))
+  const showYear = !slotsAreInSameYear(minTime, maxTime, timeWindow)
+
+
+  // Loop over all emission points defined in data/domain/types/emissions/EmissionTypes.ts#L9
+  points.forEach((emissionPoint) => {
+    const categoryEra = emissionPoint.categoryEraName
+    // Initialize result for era if needed TODO: swap for category code
+    if (!result[categoryEra]) {
+      result[categoryEra] = {}
+    }
+
+    if (emissionPoint.startTimeSlot < timeWindow.timeOffsets.length - 1) // test data contains values out of bounds
+    { 
+      const totalTimeOffset = getTimeOffsetForSlot(
+        emissionPoint.startTimeSlot,
+        timeWindow,
+      )
+
+      const timeKey = timeMeasureKeyFn(
+        timeWindow.startTimestamp + totalTimeOffset,
+        showYear,
+      )
+
+      if (!result[categoryEra][timeKey]) {
+        result[categoryEra][timeKey] = 0
+      }
+  
+      result[categoryEra][timeKey] += emissionPoint.totalEmissionAmount
+    }
+  })
+  return result
+}
+
+/* Work in Progress
+*  groups based on datapicker, so if there is missing data in the response, or extra data the chart displays correctly
+export const emissionsGroupByTime = (
+  points: EmissionDataPoint[],
+  timeWindow: TimeWindow,
+  timeMeasureKeyFn: (timestamp: number, showYear: boolean) => string,
+  dataPickerWindow: TimeRange
+): Record<string, Record<string, number>> => {
+  const result: Record<string, Record<string, number >> = {}
+  const minTime = Math.min(...points.map((point) => point.startTimeSlot))
+  const maxTime = Math.max(...points.map((point) => point.endTimeSlot))
+  const showYear = !slotsAreInSameYear(minTime, maxTime, timeWindow)
+
+  // create list of timekeys that match datapicker range
+  const startDataPickerTime = dataPickerWindow.start
+  const endDataPickerTime = dataPickerWindow.end
+  const timestep = getTimeOffsetForSlot(1,timeWindow)
+  let sum = startDataPickerTime
+  const dataPickerKeys: string[] = []
+  do {
+    dataPickerKeys.push(timeMeasureKeyFn(sum,showYear))
+    sum += timestep
+  } while (sum < endDataPickerTime)
+
+  // Loop over all emission points defined in data/domain/types/emissions/EmissionTypes.ts#L9
+  points.forEach((emissionPoint) => {
+    const categoryEra = emissionPoint.categoryEraName
+    // Initialize result for era if needed TODO: swap for category code
+    if (!result[categoryEra]) {
+      result[categoryEra] = {}
+      dataPickerKeys.forEach(timeKey => {
+        result[categoryEra][timeKey] = 0;
+      });    
+    }
+
+    if (emissionPoint.startTimeSlot < timeWindow.timeOffsets.length - 1) 
+    { // test data contains values out of bounds
+      const totalTimeOffset = getTimeOffsetForSlot(
+        emissionPoint.startTimeSlot,
+        timeWindow,
+      )
+
+      const timeKey = timeMeasureKeyFn(
+        timeWindow.startTimestamp + totalTimeOffset,
+        showYear,
+      )
+
+      if (timeKey in result[categoryEra]) {
+        result[categoryEra][timeKey] += emissionPoint.totalEmissionAmount
+      }
+    }
+  })
+  return result
+}
+*/
 
 export const getScopesOfProtocol = (
   protocol: EmissionProtocol,

--- a/src/data/domain/transformers/EmissionTransformers.ts
+++ b/src/data/domain/transformers/EmissionTransformers.ts
@@ -78,6 +78,7 @@ export const formatEmissionIntensityUnit = (scale: string): string => {
       return ""
   }
 }
+
 export const extractNameOfEra = (era: string | undefined) => {
   if (typeof era === "undefined") {
     return ""
@@ -119,6 +120,9 @@ const calculateTotalAmount = (
     // count from start until max slot
     duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_START_PERCENTAGE] * getTimeDeltaForSlot(startTimeSlot, timeWindow) +
     (getTimeOffsetForSlot(maxSlot, timeWindow) - getTimeOffsetForSlot(startTimeSlot + 1, timeWindow))
+  } else if (startTimeSlot == endTimeSlot - 1) {
+    // single slot
+    duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_END_PERCENTAGE]  * getTimeDeltaForSlot(startTimeSlot, timeWindow)
   } else {
     // standard calculation
     duration = dataPoint[CdpLayoutItem.CDP_LAYOUT_START_PERCENTAGE] * getTimeDeltaForSlot(startTimeSlot, timeWindow) +

--- a/src/data/store/features/emissions/ranges/EmissionRangesSlice.ts
+++ b/src/data/store/features/emissions/ranges/EmissionRangesSlice.ts
@@ -196,8 +196,7 @@ const computeTimeOffset = (startTimestamp: number, endTimestamp: number, timeSte
     index++
   } while (startTimestamp + sum < endTimestamp)
 
-  timeOffsets.push(endTimestamp - startTimestamp) // last value pushed
-
+  timeOffsets.push(sum)
   return timeOffsets
 }
 

--- a/src/data/store/features/emissions/ranges/EmissionRangesSlice.ts
+++ b/src/data/store/features/emissions/ranges/EmissionRangesSlice.ts
@@ -189,7 +189,7 @@ const computeTimeOffset = (startTimestamp: number, endTimestamp: number, timeSte
     timeOffsets.push(sum)
     sum += timeStepInSecondsPattern[index % n] * 1000
     index++
-  } while (sum < endTimestamp)
+  } while (startTimestamp + sum < endTimestamp)
 
   timeOffsets.push(endTimestamp - startTimestamp) // last value pushed
 

--- a/src/pages/natixar/ClimateChangePage.tsx
+++ b/src/pages/natixar/ClimateChangePage.tsx
@@ -68,14 +68,15 @@ const NatixarChart = () => {
   const allPoints = useSelector(emissionsSelector)
   const timeWindow = useSelector(selectTimeWindow)
 
-  let minTime = Math.min(...allPoints.map((point) => point.startTimeSlot))
-  minTime =
-    timeWindow.startTimestamp + getTimeOffsetForSlot(minTime, timeWindow)
+  let minTimeSlot = Math.min(...allPoints.map((point) => point.startTimeSlot))
+  let maxTimeSlot = Math.max(...allPoints.map((point) => point.endTimeSlot))
 
-  let maxTime = Math.max(...allPoints.map((point) => point.endTimeSlot))
-  maxTime =
-    timeWindow.startTimestamp + getTimeOffsetForSlot(maxTime, timeWindow)
+  let minTime =  timeWindow.startTimestamp + getTimeOffsetForSlot(minTimeSlot, timeWindow)
+  let maxTime =  timeWindow.startTimestamp + getTimeOffsetForSlot(maxTimeSlot, timeWindow)
 
+  // above calculation may be out of bounds so take window directly
+  minTime = timeWindow.startTimestamp
+  maxTime = timeWindow.endTimestamp
   const minDate = new Date(minTime)
   const maxDate = new Date(maxTime)
 

--- a/src/sections/charts/emissions/TotalEmissionByTimeSection.tsx
+++ b/src/sections/charts/emissions/TotalEmissionByTimeSection.tsx
@@ -2,7 +2,7 @@ import EmissionByKeyStacked from "components/charts/emissions/EmissionByKeyStack
 import { ChartCard } from "components/natixarComponents/ChartCard/ChartCard"
 import { selectTimeWindow as timeWindowSelector } from "data/store/api/EmissionSelectors"
 import {
-  emissionsGroupByTime,
+  emissionsIntensityGroupByTime,
   formatEmissionAmount,
 } from "data/domain/transformers/EmissionTransformers"
 import { EmissionDataPoint } from "data/domain/types/emissions/EmissionTypes"
@@ -54,7 +54,7 @@ const TotalEmissionByTimeSection = ({
     Record<string, Record<string, number>>
   >({})
   useAsyncWork(
-    () => emissionsGroupByTime(emissionPoints, timeWindow, timeFormatter),
+    () => emissionsIntensityGroupByTime(emissionPoints, timeWindow, timeFormatter),
     setChartData,
     [emissionPoints, timeWindow, timeFormatter],
   )
@@ -76,7 +76,7 @@ const TotalEmissionByTimeSection = ({
       selectedSlot={timeDetailUnit}
       setSelectedSlot={setTimeDetailUnit}
     >
-      <EmissionByKeyStacked groupedData={groupedByTime} keys={allKeys} />
+      <EmissionByKeyStacked groupedData={groupedByTime} keys={allKeys} timeUnit={timeDetailUnit}/>
     </ChartCard>
   )
 }


### PR DESCRIPTION
Add new function emissionsGroupIntensityByTime to display the intensities for the Time Section chart
Update timeoffsets function so it correctly generates the time slices.
Added some error checking where test data is returning unexpected time slices.